### PR TITLE
per-target opencv dependency, make tools and cli builds optional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,9 +7,13 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 option(BUILD_TESTS "Build the tests" OFF)
 option(BUILD_PYTHON_BINDINGS "Build Python bindings" OFF)
+option(BUILD_TOOLS "Build the tools library" ON)
 
 include(GNUInstallDirs)
 include(CMakePackageConfigHelpers)
+include(CMakeDependentOption)
+
+cmake_dependent_option(BUILD_CLI "Build the command line tools" ON "BUILD_TOOLS" OFF)
 
 list(PREPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake")
 
@@ -17,12 +21,13 @@ if(BUILD_TESTS)
     enable_testing()
 endif()
 
-set(ARMVO_OPENCV_COMPONENTS core imgproc video highgui features2d calib3d imgcodecs)
-find_package(OpenCV REQUIRED COMPONENTS ${ARMVO_OPENCV_COMPONENTS})
-
 add_subdirectory(lib)
-add_subdirectory(tools)
-add_subdirectory(cli)
+if(BUILD_TOOLS)
+    add_subdirectory(tools)
+endif()
+if(BUILD_CLI)
+    add_subdirectory(cli)
+endif()
 
 set(ARMVO_INSTALL_CMAKEDIR "${CMAKE_INSTALL_LIBDIR}/cmake/armvo")
 

--- a/README.md
+++ b/README.md
@@ -83,12 +83,14 @@ sudo ldconfig
 
 | Option | Default | Description |
 |---|---:|---|
-| `BUILD_TESTS` | `OFF` | Build unit tests |
+| `BUILD_TOOLS` | `ON` | Build the tools library (contains helper utilities) |
+| `BUILD_CLI` | `ON` | Build the command-line tools. This option is enabled only when `BUILD_TOOLS` is also enabled |
 | `BUILD_PYTHON_BINDINGS` | `OFF` | Build the Python bindings for the core ARM-VO library |
+| `BUILD_TESTS` | `OFF` | Build unit tests |
 
 ## Run on KITTI dataset
-Download the odometry dataset from [here](https://s3.eu-central-1.amazonaws.com/avg-kitti/data_odometry_color.zip).
-Open a terminal, navigate to build/cli folder and run:
+Download the odometry dataset from [here](https://s3.eu-central-1.amazonaws.com/avg-kitti/data_odometry_color.zip) and
+build ARM-VO with `-DBUILD_CLI=ON`. Then, open a terminal, navigate to build/cli folder and run:
 ```bash
 ./run_armvo --image_folder=path/to/downloaded/images/folder --config=path/to/config.yaml
 ```
@@ -105,8 +107,8 @@ find_package(armvo REQUIRED CONFIG)
 target_link_libraries(my_app PRIVATE armvo::ArmVO)
 ```
 
-The package also exports `armvo::ArmVOtools` for helper utilities. Link it if
-your application needs the tools API:
+The package also exports `armvo::ArmVOtools` for helper utilities when ARM-VO is
+built with `BUILD_TOOLS=ON`. You can link it by:
 ```cmake
 find_package(armvo REQUIRED CONFIG)
 target_link_libraries(my_app PRIVATE armvo::ArmVO armvo::ArmVOtools)

--- a/cmake/armvoConfig.cmake.in
+++ b/cmake/armvoConfig.cmake.in
@@ -2,7 +2,7 @@
 
 include(CMakeFindDependencyMacro)
 
-find_dependency(OpenCV REQUIRED COMPONENTS @ARMVO_OPENCV_COMPONENTS@)
+find_dependency(OpenCV REQUIRED COMPONENTS core)
 
 include("${CMAKE_CURRENT_LIST_DIR}/armvoTargets.cmake")
 

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -16,6 +16,8 @@ file(GLOB LIB_SOURCES
     "src/*.cpp"
     "src/*.hpp")
 
+find_package(OpenCV REQUIRED COMPONENTS core imgproc video features2d calib3d)
+
 find_package(TensorRT 8.6 QUIET)
 if(TensorRT_FOUND AND TensorRT_VERSION VERSION_LESS 9.0)
     set(ARMVO_USE_TENSORRT ON)
@@ -49,7 +51,16 @@ target_include_directories(ArmVO
 target_compile_features(ArmVO PUBLIC cxx_std_17)
 target_compile_definitions(ArmVO PRIVATE ${ARMVO_ARCH_DEFINITION})
 target_compile_options(ArmVO PRIVATE ${ARMVO_ARCH_COMPILE_OPTIONS})
-target_link_libraries(ArmVO PUBLIC ${OpenCV_LIBS} PRIVATE dl)
+target_link_libraries(ArmVO
+    PUBLIC
+        opencv_core
+    PRIVATE
+        opencv_imgproc
+        opencv_video
+        opencv_features2d
+        opencv_calib3d
+        dl
+)
 
 if(ARMVO_USE_TENSORRT)
     target_compile_definitions(ArmVO PRIVATE ARMVO_USE_TENSORRT)

--- a/lib/tests/CMakeLists.txt
+++ b/lib/tests/CMakeLists.txt
@@ -8,12 +8,12 @@ target_link_libraries(test_load_config PRIVATE Catch2::Catch2WithMain ArmVO)
 catch_discover_tests(test_load_config)
 
 add_executable(test_arm_vo test_arm_vo.cpp)
-target_link_libraries(test_arm_vo PRIVATE Catch2::Catch2WithMain ArmVO)
+target_link_libraries(test_arm_vo PRIVATE Catch2::Catch2WithMain ArmVO opencv_imgproc)
 catch_discover_tests(test_arm_vo)
 
 add_executable(test_keypoint_detector test_keypoint_detector.cpp)
 target_include_directories(test_keypoint_detector PRIVATE ${ARMVO_PRIVATE_TEST_INCLUDE_DIR})
-target_link_libraries(test_keypoint_detector PRIVATE Catch2::Catch2WithMain ArmVO)
+target_link_libraries(test_keypoint_detector PRIVATE Catch2::Catch2WithMain ArmVO opencv_features2d opencv_imgproc)
 catch_discover_tests(test_keypoint_detector)
 
 add_executable(test_keypoint_sampler test_keypoint_sampler.cpp)
@@ -23,15 +23,15 @@ catch_discover_tests(test_keypoint_sampler)
 
 add_executable(test_keypoint_tracker test_keypoint_tracker.cpp)
 target_include_directories(test_keypoint_tracker PRIVATE ${ARMVO_PRIVATE_TEST_INCLUDE_DIR})
-target_link_libraries(test_keypoint_tracker PRIVATE Catch2::Catch2WithMain ArmVO)
+target_link_libraries(test_keypoint_tracker PRIVATE Catch2::Catch2WithMain ArmVO opencv_imgproc)
 catch_discover_tests(test_keypoint_tracker)
 
 add_executable(test_geometry test_geometry.cpp)
 target_include_directories(test_geometry PRIVATE ${ARMVO_PRIVATE_TEST_INCLUDE_DIR})
-target_link_libraries(test_geometry PRIVATE Catch2::Catch2WithMain ArmVO)
+target_link_libraries(test_geometry PRIVATE Catch2::Catch2WithMain ArmVO opencv_calib3d opencv_imgproc)
 catch_discover_tests(test_geometry)
 
 add_executable(test_semantic_segmentor test_semantic_segmentor.cpp)
 target_include_directories(test_semantic_segmentor PRIVATE ${ARMVO_PRIVATE_TEST_INCLUDE_DIR})
-target_link_libraries(test_semantic_segmentor PRIVATE Catch2::Catch2WithMain ArmVO)
+target_link_libraries(test_semantic_segmentor PRIVATE Catch2::Catch2WithMain ArmVO opencv_imgproc)
 catch_discover_tests(test_semantic_segmentor)

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -2,6 +2,8 @@ file(GLOB TOOLS_SOURCES
      CONFIGURE_DEPENDS
      "src/*.cpp")
 
+find_package(OpenCV REQUIRED COMPONENTS core imgproc highgui imgcodecs)
+
 add_library(ArmVOtools SHARED)
 target_sources(ArmVOtools PRIVATE ${TOOLS_SOURCES})
 target_include_directories(ArmVOtools
@@ -11,7 +13,15 @@ target_include_directories(ArmVOtools
         $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
 target_compile_features(ArmVOtools PUBLIC cxx_std_17)
-target_link_libraries(ArmVOtools PUBLIC ArmVO ${OpenCV_LIBS})
+target_link_libraries(ArmVOtools
+    PUBLIC
+        ArmVO
+        opencv_core
+    PRIVATE
+        opencv_imgproc
+        opencv_highgui
+        opencv_imgcodecs
+)
 set_target_properties(ArmVOtools PROPERTIES
     VERSION ${PROJECT_VERSION}
     SOVERSION ${PROJECT_VERSION_MAJOR}

--- a/tools/tests/CMakeLists.txt
+++ b/tools/tests/CMakeLists.txt
@@ -2,7 +2,7 @@ find_package(Catch2 2 REQUIRED CONFIG)
 include(Catch)
 
 add_executable(test_file_tools test_file_tools.cpp)
-target_link_libraries(test_file_tools PRIVATE Catch2::Catch2WithMain ArmVOtools)
+target_link_libraries(test_file_tools PRIVATE Catch2::Catch2WithMain ArmVOtools opencv_imgcodecs opencv_imgproc)
 catch_discover_tests(test_file_tools)
 
 add_executable(test_error_estimator test_error_estimator.cpp)


### PR DESCRIPTION
1. I added build options for the tools library and CLI. Their defaults are ON, but if a user is only interested in the core ARM-VO library, they can pass `-DBUILD_TOOLS=OFF -DBUILD_CLI=OFF`
2. Also, instead of a global `find_package` call for OpenCV, each library (the core and tools) asks for what it needs. As a result, one doesn't need to have OpenCV's `highgui` module if they just want the core ARM-VO library.